### PR TITLE
Fix tests after updates to var names.

### DIFF
--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -622,10 +622,24 @@ class SAMLAuthenticator(Authenticator):
             # say something like "if adding the user is successful, return username"
             return not subprocess.call([self.create_system_user_binary, username])
 
+    # JH did a clumsy job of renaming (white|black)list -> (allowed|blocked)_users,
+    # so it falls on me to paper over their mistakes.
+    def _check_blocked_users(self, username):
+        try:
+            return self.check_blacklist(username)
+        except DeprecationWarning:
+            return self.check_blocked_users(username)
+
+    def _check_allowed_users(self, username):
+        try:
+            return self.check_whitelist(username)
+        except DeprecationWarning:
+            return self.check_allowed_users(username)
+
     def _check_username_and_add_user(self, username):
         if self.validate_username(username) and \
-                self.check_blacklist(username) and \
-                self.check_whitelist(username):
+                self._check_blocked_users(username) and \
+                self._check_allowed_users(username):
             if self.create_system_users:
                 if self._optional_user_add(username):
                     # Successfully added user

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -619,12 +619,14 @@ class TestCreateUser(unittest.TestCase):
         a._optional_user_add = MagicMock()
         a._optional_user_add.return_value = True
         a.whitelist = {'bluedata'}
+        a.allowed_users = {'bluedata'}
 
         assert a._check_username_and_add_user('bluedata')
 
         a._optional_user_add.assert_called_once_with('bluedata')
 
         a.whitelist = {'not_bluedata'}
+        a.allowed_users = {'not_bluedata'}
         a._optional_user_add.reset_mock()
 
         assert not a._check_username_and_add_user('bluedata')
@@ -636,12 +638,14 @@ class TestCreateUser(unittest.TestCase):
         a._optional_user_add = MagicMock()
         a._optional_user_add.return_value = True
         a.blacklist = {'bluedata'}
+        a.blocked_users = {'bluedata'}
 
         assert not a._check_username_and_add_user('bluedata')
 
         a._optional_user_add.assert_not_called()
 
         a.blacklist = {'not_bluedata'}
+        a.blocked_users = {'blocked_users'}
 
         assert a._check_username_and_add_user('bluedata')
 


### PR DESCRIPTION
JupyterHub updated their wording from `(black|white)list` to `(blocked|allowed)_users`, and the code was not handling it well. This PR should fix those failures.

I'm disappointed in JupyterHub that they decided to break backward compatibility in this way on a minor version release. I think that the intent behind the change is good, but the actual change is clumsy and haphazard.

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Thomas Kelley <distortedsignal@gmail.com>
