### PR TITLE
Update roles documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The default nameid format that the SAMLAuthenticator expects is defined by the S
 
 If the server administrator wants to create local users for each JupyterHub user but doesn't want to use the `useradd` utility, a user can be added with any binary on the host system Set the `create_system_user_binary` field to either a) a full path to the binary or b) the name of a binary on the host's path. Please note, if the binary exits with code 0, the Authenticator will assume that the user add succeeded, and if the binary exits with any code _other than 0_, it will be assumed that creating the user failed.
 
-Access is given to all users who successfully authenticate regardless of their role or group membership by default. Set the `roles` field to restrict access to JupyterHub to specific roles. Users with any of the specified roles will be authorized to access JupyterHub. The `xpath_role_location` field can be configured to set the location of the users roles in the SAML response.
+Access is given to all users who successfully authenticate regardless of their role or group membership by default. Set the `allowed_roles` field to restrict access to JupyterHub to specific roles. Users with any of the specified roles will be authorized to access JupyterHub. The `xpath_role_location` field can be configured to set the location of the users roles in the SAML response.
 
 #### Example Configurations
 
@@ -123,7 +123,7 @@ c.SAMLAuthenticator.xpath_username_location = '//saml:Attribute[@Name="DottedNam
 c.SAMLAuthenticator.xpath_role_location = '//saml:Attribute[@Name="Roles"]/saml:AttributeValue/text()'
 
 # Comma-separated list of authorized roles. Allows all if not specified.
-c.SAMLAuthenticator.roles = 'group1,group2'
+c.SAMLAuthenticator.allowed_roles = 'group1,group2'
 
 # The IdP is sending the SAML Response in a field named 'R'
 c.SAMLAuthenticator.login_post_field = 'R'


### PR DESCRIPTION
Updated documentation related to `allowed_roles` to match code (#56).

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Mitchel Haring <mitchel.haring@gmail.com>
