### PR TITLE
Generate SAMLRequst URL query parameter for unsigned SP-initiated login

### DIFF
--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -725,19 +725,18 @@ class SAMLAuthenticator(Authenticator):
         handler_self.log.debug('Final xpath is: ' + final_xpath)
 
         redirect_link_getter = xpath_with_namespaces(final_xpath)
+        sso_login_url = redirect_link_getter(saml_metadata_etree)[0]
 
+        # AWS SSO does not require a signed request so this is fairly simple. 
         saml_request=quote_plus(b64encode(zlib.compress(f"""
-        <samlp:AuthnRequest ID="0" Version="2.0" IssueInstant="{datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}" Destination="https://portal.sso.eu-west-2.amazonaws.com/saml/assertion/NjMxMDEzMTQzODk3X2lucy0xNGM0MGNkNmM2ZDgxNGZm" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="http://localhost:8000/hub/login" ProviderName="" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
-        <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">http://localhost:8000/hub</saml:Issuer>
+        <samlp:AuthnRequest ID="0" Version="2.0" IssueInstant="{datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}" Destination="{sso_login_url}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="{authenticator_self.acs_endpoint_url}" ProviderName="" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+        <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">{authenticator_self.audience}</saml:Issuer>
         <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" AllowCreate="true"/>
         </samlp:AuthnRequest>""".encode('utf8'))[2:-4]))
 
-        # see https://developers.onelogin.com/saml/examples/authnrequest
-        #     https://stackoverflow.com/questions/30388926/http-redirect-binding-saml-request
-
         # Here permanent MUST BE False - otherwise the /hub/logout GET will not be fired
         # by the user's browser.
-        handler_self.redirect(f"{redirect_link_getter(saml_metadata_etree)[0]}?SAMLRequest={saml_request}", permanent=False)
+        handler_self.redirect(f"{sso_login_url}?SAMLRequest={saml_request}", permanent=False)
 
     def _make_org_metadata(self):
         if self.organization_name or \

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -719,15 +719,14 @@ class SAMLAuthenticator(Authenticator):
         handler_self.log.debug('Got valid metadata etree')
 
         xpath_with_namespaces = authenticator_self._make_xpath_builder()
+
         binding = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
         final_xpath = '//' + element_name + '[@Binding=\'' + binding + '\']/@Location'
-
         handler_self.log.debug('Final xpath is: ' + final_xpath)
         
         redirect_link_getter = xpath_with_namespaces(final_xpath)
-        sso_login_url = redirect_link_getter(saml_metadata_etree)[0]
-        
-        return sso_login_url
+
+        return redirect_link_getter(saml_metadata_etree)[0]
 
     def _get_redirect_from_metadata_and_redirect(authenticator_self, element_name, handler_self, add_authn_request=False):
 
@@ -735,7 +734,6 @@ class SAMLAuthenticator(Authenticator):
 
         # Here permanent MUST BE False - otherwise the /hub/logout GET will not be fired
         # by the user's browser.
-
         if add_authn_request:
             authn_requst = quote_plus(b64encode(zlib.compress(
                 authenticator_self._make_authn_request(element_name, handler_self).encode('utf8')

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -731,7 +731,6 @@ class SAMLAuthenticator(Authenticator):
         saml_request=quote_plus(b64encode(zlib.compress(f"""
         <samlp:AuthnRequest ID="0" Version="2.0" IssueInstant="{datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}" Destination="{sso_login_url}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="{authenticator_self.acs_endpoint_url}" ProviderName="" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
         <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">{authenticator_self.audience}</saml:Issuer>
-        <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" AllowCreate="true"/>
         </samlp:AuthnRequest>""".encode('utf8'))[2:-4]))
 
         # Here permanent MUST BE False - otherwise the /hub/logout GET will not be fired

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -723,7 +723,7 @@ class SAMLAuthenticator(Authenticator):
         binding = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
         final_xpath = '//' + element_name + '[@Binding=\'' + binding + '\']/@Location'
         handler_self.log.debug('Final xpath is: ' + final_xpath)
-        
+
         redirect_link_getter = xpath_with_namespaces(final_xpath)
 
         return redirect_link_getter(saml_metadata_etree)[0]
@@ -846,10 +846,11 @@ class SAMLAuthenticator(Authenticator):
 
             async def get(login_handler_self):
                 login_handler_self.log.info('Starting SP-initiated SAML Login')
-                authenticator_self._get_redirect_from_metadata_and_redirect('md:SingleSignOnService',
-                                                                            login_handler_self,
-                                                                            add_authn_request=True
-                                                                            )
+                authenticator_self._get_redirect_from_metadata_and_redirect(
+                    'md:SingleSignOnService',
+                    login_handler_self,
+                    add_authn_request=True
+                )
 
         class SAMLLogoutHandler(LogoutHandler):
             # TODO: When the time is right to force users onto JupyterHub 1.0.0,
@@ -892,10 +893,11 @@ class SAMLAuthenticator(Authenticator):
                 forward_on_logout = True if authenticator_self.slo_forward_on_logout else False
                 forwad_on_logout = True if authenticator_self.slo_forwad_on_logout else False
                 if forward_on_logout or forwad_on_logout:
-                    authenticator_self._get_redirect_from_metadata_and_redirect('md:SingleLogoutService',
-                                                                                logout_handler_self,
-                                                                                add_authn_request=False
-                                                                                )
+                    authenticator_self._get_redirect_from_metadata_and_redirect(
+                        'md:SingleLogoutService',
+                        logout_handler_self,
+                        add_authn_request=False
+                    )
                 else:
                     html = logout_handler_self.render_template('logout.html')
                     logout_handler_self.finish(html)


### PR DESCRIPTION
This adds a minimal SAMLRequest to the login redirect so that SP-initiated login works as expected. 

To do:
* add some tests
* check for presence of WantAuthnRequestsSigned="false" in IDP metadata before generating the request (revert to plain redirect if true?)
* make sure the generated request is consistent with output of _make_sp_metadata() and also respects IDP metadata
```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Tom Catling tomcatling@gmail.com