### PR TITLE
Added sync=True argument to the render_template method call

### DIFF
--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -851,7 +851,6 @@ class SAMLAuthenticator(Authenticator):
                     authenticator_self._get_redirect_from_metadata_and_redirect('md:SingleLogoutService',
                                                                                 logout_handler_self)
                 else:
-                    html = logout_handler_self.render_template('logout.html')
                     html = logout_handler_self.render_template('logout.html', sync=True)
                     logout_handler_self.finish(html)
 

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -852,6 +852,7 @@ class SAMLAuthenticator(Authenticator):
                                                                                 logout_handler_self)
                 else:
                     html = logout_handler_self.render_template('logout.html')
+                    html = logout_handler_self.render_template('logout.html', sync=True)
                     logout_handler_self.finish(html)
 
         class SAMLMetaHandler(BaseHandler):


### PR DESCRIPTION
Small change, adding "sync=True" argument to the render_template method call.
It is needed as since Jupyterhub version 1.3.0, render_template will run in async mode by default and the logout template is never awaited. 

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Kristina Kyoreva <kristina.kyoreva@gmail.com>
